### PR TITLE
Fixing region us-east-1

### DIFF
--- a/sign_s3_url.bash
+++ b/sign_s3_url.bash
@@ -179,6 +179,11 @@ function main()
         fatal "\nERROR: region must be valid string of: $(getAllowRegions)!\n"
     fi
 
+    if [[ "${region}" = 'us-east-1' ]]
+    then
+        region=""
+    fi
+
     generateSignURL "${region}" "${bucket}" "${filePath}" "${awsAccessKeyID}" "${awsSecretAccessKey}" "${method}" "${minuteExpire}"
 }
 


### PR DESCRIPTION
With this, cli accepts to run without region parameter.
If calling without region (or region with us-east-1 value) it lets region empty and the endPoint is set to s3.amazonaws.com.
