### PR TITLE
read AWS credentials from EC2 CLI tools env variables

### DIFF
--- a/sign_s3_url.bash
+++ b/sign_s3_url.bash
@@ -78,8 +78,8 @@ function main()
     local optCount=${#}
 
     local region="${AWS_DEFAULT_REGION}"
-    local awsAccessKeyID="${AWS_ACCESS_KEY_ID}"
-    local awsSecretAccessKey="${AWS_SECRET_ACCESS_KEY}"
+    local awsAccessKeyID="${AWS_ACCESS_KEY_ID:-${AWS_ACCESS_KEY}}"
+    local awsSecretAccessKey="${AWS_SECRET_ACCESS_KEY:-${AWS_SECRET_KEY}}"
     method='GET'
     minuteExpire=15
 


### PR DESCRIPTION
EC2 CLI tools use `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`, as described in http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/set-up-ec2-cli-linux.html

This PR makes the code attempt to use those env variables if the regular ones are not there.