### PR TITLE
Make the endpoint https

### DIFF
--- a/sign_s3_url.bash
+++ b/sign_s3_url.bash
@@ -66,7 +66,7 @@ function generateSignURL()
                        openssl base64)"
     local query="AWSAccessKeyId=$(encodeURL "${awsAccessKeyID}")&Expires=${expire}&Signature=$(encodeURL "${signature}")"
 
-    echo "http://${endPoint}/${bucket}/${filePath}?${query}"
+    echo "https://${endPoint}/${bucket}/${filePath}?${query}"
 }
 
 function main()


### PR DESCRIPTION
Probably better to make the protocol of endpoint https by default to stop URLs being snarfed in transit